### PR TITLE
Improving painting methods, especially for drawing

### DIFF
--- a/src/app/client.cpp
+++ b/src/app/client.cpp
@@ -91,7 +91,7 @@ client::client(
     if (pen_device != nullptr)
     {
         this->pen_handler.emplace(
-            *pen_device, screen_device,
+            *pen_device, this->screen_handler,
             button_callback);
         this->poll_pen = this->polled_fds.size();
         this->polled_fds.push_back(pollfd{});

--- a/src/app/pen.cpp
+++ b/src/app/pen.cpp
@@ -16,6 +16,7 @@ pen::pen(
 : device(device)
 , screen(screen)
 , send_button_press(std::move(send_button_press))
+, state(MouseButton::None)
 {}
 
 auto pen::process_events() -> event_loop_status
@@ -38,12 +39,13 @@ auto pen::process_events() -> event_loop_status
 
             // Move cursor to pen position, generate a click if the pen is
             // touching the screen
-            this->send_button_press(
-                screen_x, screen_y,
-                device_state.pressure > 0
-                    ? MouseButton::Left
-                    : MouseButton::None
-            );
+            MouseButton new_state =
+               device_state.pressure > 0
+                ? MouseButton::Left
+                : MouseButton::None;
+            this->send_button_press(screen_x, screen_y, new_state);
+
+            this->state = new_state;
         }
     }
 

--- a/src/app/pen.cpp
+++ b/src/app/pen.cpp
@@ -46,10 +46,12 @@ auto pen::process_events() -> event_loop_status
             this->send_button_press(screen_x, screen_y, new_state);
 
             if (this->state != new_state) {
-                if (this->state == MouseButton::Left)
+                if (new_state == MouseButton::Left)
                     this->screen.set_repainting_mode(repainting_mode::fast);
-                else
+                else {
+                    this->screen.repaint();
                     this->screen.set_repainting_mode(repainting_mode::standard);
+                }
             }
             this->state = new_state;
         }

--- a/src/app/pen.cpp
+++ b/src/app/pen.cpp
@@ -45,6 +45,12 @@ auto pen::process_events() -> event_loop_status
                 : MouseButton::None;
             this->send_button_press(screen_x, screen_y, new_state);
 
+            if (this->state != new_state) {
+                if (this->state == MouseButton::Left)
+                    this->screen.set_repainting_mode(repainting_mode::fast);
+                else
+                    this->screen.set_repainting_mode(repainting_mode::standard);
+            }
             this->state = new_state;
         }
     }

--- a/src/app/pen.cpp
+++ b/src/app/pen.cpp
@@ -10,11 +10,11 @@ namespace app
 
 pen::pen(
     rmioc::pen& device,
-    const rmioc::screen& screen_device,
+    app::screen& screen,
     MouseCallback send_button_press
 )
 : device(device)
-, screen_device(screen_device)
+, screen(screen)
 , send_button_press(std::move(send_button_press))
 {}
 
@@ -27,8 +27,8 @@ auto pen::process_events() -> event_loop_status
         if (device_state.tool_set.pen())
         {
             // Convert to screen coordinates
-            int xres = static_cast<int>(this->screen_device.get_xres());
-            int yres = static_cast<int>(this->screen_device.get_yres());
+            int xres = static_cast<int>(this->screen.get_xres());
+            int yres = static_cast<int>(this->screen.get_yres());
 
             int screen_x = device_state.y * xres
                 / rmioc::pen::pen_state::y_max;

--- a/src/app/pen.hpp
+++ b/src/app/pen.hpp
@@ -37,6 +37,9 @@ private:
 
     /** Callback for sending mouse events. */
     MouseCallback send_button_press;
+
+    /** Current state of the pen */
+    MouseButton state;
 };
 
 } // namespace app

--- a/src/app/pen.hpp
+++ b/src/app/pen.hpp
@@ -2,6 +2,7 @@
 #define APP_PEN_HPP
 
 #include "event_loop.hpp"
+#include "screen.hpp"
 
 namespace rmioc
 {
@@ -17,7 +18,7 @@ class pen
 public:
     pen(
         rmioc::pen& device,
-        const rmioc::screen& screen_device,
+        app::screen& screen_device,
         MouseCallback send_button_press
     );
 
@@ -31,8 +32,8 @@ private:
     /** reMarkable pen digitizer device. */
     rmioc::pen& device;
 
-    /** reMarkable screen device. */
-    const rmioc::screen& screen_device;
+    /** reMarkable screen. */
+    app::screen& screen;
 
     /** Callback for sending mouse events. */
     MouseCallback send_button_press;

--- a/src/app/screen.cpp
+++ b/src/app/screen.cpp
@@ -40,6 +40,19 @@ screen::screen(rmioc::screen& device, rfbClient* vnc_client)
     this->vnc_client->GotFrameBufferUpdate = screen::update_framebuf;
 }
 
+void screen::repaint()
+{
+     this->update_info.has_update = false;
+
+     log::print("Screen update")
+           << this->update_info.w << 'x' << this->update_info.h << '+'
+           << this->update_info.x << '+' << this->update_info.y << '\n';
+
+     this->device.update(
+           this->update_info.x, this->update_info.y,
+           this->update_info.w, this->update_info.h
+     );
+}
 auto screen::event_loop() -> event_loop_status
 {
     if (this->update_info.has_update)
@@ -52,16 +65,7 @@ auto screen::event_loop() -> event_loop_status
 
         if (remaining_wait_time <= 0)
         {
-            this->update_info.has_update = false;
-
-            log::print("Screen update")
-                << this->update_info.w << 'x' << this->update_info.h << '+'
-                << this->update_info.x << '+' << this->update_info.y << '\n';
-
-            this->device.update(
-                this->update_info.x, this->update_info.y,
-                this->update_info.w, this->update_info.h
-            );
+            this->repaint();
         }
         else
         {

--- a/src/app/screen.cpp
+++ b/src/app/screen.cpp
@@ -21,12 +21,19 @@ namespace chrono = std::chrono;
  */
 constexpr chrono::milliseconds update_delay{150};
 
+/**
+ * Maximum time to wait in between two repaints. If the screen is unstable, then the
+ * first mechanism might never repaint the screen.
+ */
+constexpr chrono::milliseconds update_max_delay{500};
+
 namespace app
 {
 
 screen::screen(rmioc::screen& device, rfbClient* vnc_client)
 : device(device)
 , vnc_client(vnc_client)
+, repaint_mode(repainting_mode::standard)
 {
     rfbClientSetClientData(
         this->vnc_client,
@@ -45,9 +52,10 @@ void screen::repaint(bool direct)
     /* If the update is direct, we don't clear the has_update flag
           * Since direct updates only update black pixel, we still need to do a proper update every once in a whil
           */
-    if(!direct)
+    if(!direct) {
        this->update_info.has_update = false;
-
+       this->update_info.last_repaint_time = chrono::steady_clock::now();
+    }
     log::print("Screen update")
         << this->update_info.w << 'x' << this->update_info.h << '+'
         << this->update_info.x << '+' << this->update_info.y << '\n';
@@ -66,24 +74,40 @@ int screen::get_yres()
 {
     return this->device.get_yres();
 }
+ 
+void screen::set_repainting_mode(repainting_mode mode)
+{
+    this->repaint_mode = mode;
+}
+
+   
 auto screen::event_loop() -> event_loop_status
 {
     if (this->update_info.has_update)
     {
+        auto now = chrono::steady_clock::now();
         int remaining_wait_time =
             chrono::duration_cast<chrono::milliseconds>(
                 this->update_info.last_update_time + update_delay
-                - chrono::steady_clock::now()
+                - now
             ).count();
 
-        if (remaining_wait_time <= 0)
+        int must_repaint = 
+            chrono::duration_cast<chrono::milliseconds>(
+                this->update_info.last_repaint_time + update_max_delay
+                - now
+            ).count();
+        if (remaining_wait_time <= 0 || must_repaint <= 0)
         {
             this->repaint();
         }
         else
         {
+            if (this->repaint_mode == app::repainting_mode::fast)
+                this->repaint(true);
+
             // Wait until the next update is due
-            return {/* quit = */ false, /* timeout = */ remaining_wait_time};
+            return {/* quit = */ false, /* timeout = */ std::min(remaining_wait_time, must_repaint)};
         }
     }
 

--- a/src/app/screen.cpp
+++ b/src/app/screen.cpp
@@ -40,17 +40,22 @@ screen::screen(rmioc::screen& device, rfbClient* vnc_client)
     this->vnc_client->GotFrameBufferUpdate = screen::update_framebuf;
 }
 
-void screen::repaint()
+void screen::repaint(bool direct)
 {
-     this->update_info.has_update = false;
+    /* If the update is direct, we don't clear the has_update flag
+          * Since direct updates only update black pixel, we still need to do a proper update every once in a whil
+          */
+    if(!direct)
+       this->update_info.has_update = false;
 
-     log::print("Screen update")
-           << this->update_info.w << 'x' << this->update_info.h << '+'
-           << this->update_info.x << '+' << this->update_info.y << '\n';
+    log::print("Screen update")
+        << this->update_info.w << 'x' << this->update_info.h << '+'
+        << this->update_info.x << '+' << this->update_info.y << '\n';
 
-     this->device.update(
+    this->device.update(
            this->update_info.x, this->update_info.y,
-           this->update_info.w, this->update_info.h
+           this->update_info.w, this->update_info.h,
+           direct
      );
 }
 int screen::get_xres()

--- a/src/app/screen.cpp
+++ b/src/app/screen.cpp
@@ -53,6 +53,14 @@ void screen::repaint()
            this->update_info.w, this->update_info.h
      );
 }
+int screen::get_xres()
+{
+    return this->device.get_xres();
+}
+int screen::get_yres()
+{
+    return this->device.get_yres();
+}
 auto screen::event_loop() -> event_loop_status
 {
     if (this->update_info.has_update)

--- a/src/app/screen.hpp
+++ b/src/app/screen.hpp
@@ -25,6 +25,8 @@ public:
 
     event_loop_status event_loop();
 
+    /** repaint the reMarkable screen. */
+    void repaint();
 private:
     /** reMarkable screen device. */
     rmioc::screen& device;

--- a/src/app/screen.hpp
+++ b/src/app/screen.hpp
@@ -15,6 +15,19 @@ namespace rmioc
 namespace app
 {
 
+/**
+ * Describes the different repainting mode used by the screen.
+ *
+ */
+enum repainting_mode
+{
+    /** Standard mode. */
+    standard = 0,
+
+    /** Fast mode: Direct rendering as soon as possible. */
+    fast = 1
+};
+    
 class screen
 {
 public:
@@ -33,6 +46,9 @@ public:
 
     /** get x resolution */
     int get_yres();
+
+    /** set the rendering mode */
+    void set_repainting_mode(repainting_mode);
 private:
     /** reMarkable screen device. */
     rmioc::screen& device;
@@ -81,10 +97,17 @@ private:
 
         /** Last time an update was registered. */
         std::chrono::steady_clock::time_point last_update_time;
+
+        /** Last time the reMarkable screen was repainted. */
+        std::chrono::steady_clock::time_point last_repaint_time;
     } update_info;
 
     /** Tag used for accessing the instance from C callbacks. */
     static constexpr std::size_t instance_tag = 6803;
+
+    /** Current repainting mode */
+    repainting_mode repaint_mode;
+
 }; // class screen
 
 } // namespace app

--- a/src/app/screen.hpp
+++ b/src/app/screen.hpp
@@ -26,7 +26,7 @@ public:
     event_loop_status event_loop();
 
     /** repaint the reMarkable screen. */
-    void repaint();
+    void repaint(bool direct=false);
 
     /** get x resolution */
     int get_xres();

--- a/src/app/screen.hpp
+++ b/src/app/screen.hpp
@@ -27,6 +27,12 @@ public:
 
     /** repaint the reMarkable screen. */
     void repaint();
+
+    /** get x resolution */
+    int get_xres();
+
+    /** get x resolution */
+    int get_yres();
 private:
     /** reMarkable screen device. */
     rmioc::screen& device;

--- a/src/rmioc/screen.cpp
+++ b/src/rmioc/screen.cpp
@@ -74,7 +74,7 @@ screen::~screen()
     this->framebuf_fd = -1;
 }
 
-void screen::update(int x, int y, int w, int h, bool wait)
+void screen::update(int x, int y, int w, int h, bool direct, bool wait)
 {
     // Clip update region to screen bounds
     if (x < 0)
@@ -113,7 +113,7 @@ void screen::update(int x, int y, int w, int h, bool wait)
     update.update_region.top = y;
     update.update_region.width = w;
     update.update_region.height = h;
-    update.waveform_mode = mxcfb::waveform_modes::gc16;
+    update.waveform_mode = direct ? mxcfb::waveform_modes::du : mxcfb::waveform_modes::gc16;
     update.temp = mxcfb::temps::normal;
     update.update_mode = mxcfb::update_modes::partial;
     update.flags = 0;
@@ -121,14 +121,14 @@ void screen::update(int x, int y, int w, int h, bool wait)
     this->send_update(update, wait);
 }
 
-void screen::update(bool wait)
+void screen::update(bool direct, bool wait)
 {
     mxcfb::update_data update{};
     update.update_region.left = 0;
     update.update_region.top = 0;
     update.update_region.width = this->get_xres();
     update.update_region.height = this->get_yres();
-    update.waveform_mode = mxcfb::waveform_modes::gc16;
+    update.waveform_mode = direct ? mxcfb::waveform_modes::du : mxcfb::waveform_modes::gc16;
     update.temp = mxcfb::temps::normal;
     update.update_mode = mxcfb::update_modes::full;
     update.flags = 0;

--- a/src/rmioc/screen.hpp
+++ b/src/rmioc/screen.hpp
@@ -25,16 +25,18 @@ public:
      * @param y Top bound of the region to update (in pixels).
      * @param w Width of the region to update (in pixels).
      * @param h Height of the region to update (in pixels).
+     * @param direct True to use direct mode rendering (du). 
      * @param wait True to wait until update is complete.
      */
-    void update(int x, int y, int w, int h, bool wait = false);
+    void update(int x, int y, int w, int h, bool direct = false, bool wait = false);
 
     /**
      * Perform a full update of the screen (will flash).
      *
      * @param wait True to wait until update is complete.
+     * @param direct True to use direct mode rendering (du). 
      */
-    void update(bool wait = true);
+    void update(bool direct = false, bool wait = true);
 
     /**
      * Access the screen data buffer.


### PR DESCRIPTION
This patch modifies the repainting discipline to allow smoothless drawing. There is now two painting discipline:

- The standard one, which behaves like the previous one but also forces a repaint every 500ms.

- The fast one, only used when drawing which moreover repaints updates in the direct mode, which is very fast but can only paint it black.

- Moreover, when the pen is released, we also update the screen so that the user can see the whole stroke.

This allows for drawing on shared whiteboard with a black pen with reasonable latency.

Disclaimer: I have not written a line of C++ in about a decade so I'm not really up-to-date with coding standards (not that I ever was).